### PR TITLE
Fix: Correct syntax error in dealerDiscard unit test

### DIFF
--- a/test/server/dealerDiscard.unit.test.js
+++ b/test/server/dealerDiscard.unit.test.js
@@ -285,9 +285,6 @@ describe('Euchre Server Dealer Discard Functions', function() {
                     west: { id: 'west-1', name: 'Player 2', hand: [] },
                     north: { id: 'north-1', name: 'Player 3', hand: [] },
                     east: { id: 'east-1', name: 'Player 4', hand: [] }
-                    west: { id: 'west-1', name: 'Player 2', hand: [] },
-                    north: { id: 'north-1', name: 'Player 3', hand: [] },
-                    east: { id: 'east-1', name: 'Player 4', hand: [] }
                 },
                 playerSlots: ['south', 'west', 'north', 'east'],
                 team1Score: 0, team2Score: 0,


### PR DESCRIPTION
Removes duplicate player object definitions within the players object in the 'should successfully process valid dealer discard' test case in `test/server/dealerDiscard.unit.test.js`.

This error was causing an "Unexpected identifier 'west'" SyntaxError during test execution.