### PR TITLE
Refactor: Use relative paths in test files

### DIFF
--- a/test/phases/biddingPhase.unit.test.js
+++ b/test/phases/biddingPhase.unit.test.js
@@ -98,9 +98,9 @@ describe('BiddingPhase Logic', () => {
     beforeEach(async () => {
       validateBidMock = sinon.stub();
       const biddingPhaseModule = await esmock('../../src/game/phases/biddingPhase.js', {
-        '/app/src/game/logic/validation.js': { validateBid: validateBidMock },
-        '/app/src/utils/logger.js': baseLoggerMock,
-        '/app/src/game/logic/errors.js': { PhaseLogicError }
+        '../../src/game/logic/validation.js': { validateBid: validateBidMock },
+        '../../src/utils/logger.js': baseLoggerMock,
+        '../../src/game/logic/errors.js': { PhaseLogicError }
       });
       handleOrderUpDecision = biddingPhaseModule.handleOrderUpDecision;
       gameStateInOrderUpRound1 = setupBiddingState(PLAYER_ROLES[0], 1, SUITS.DIAMONDS);
@@ -188,12 +188,12 @@ describe('BiddingPhase Logic', () => {
     beforeEach(async () => {
       validateDealerDiscardMock = sinon.stub();
       const biddingPhaseModule = await esmock('../../src/game/phases/biddingPhase.js', {
-          '/app/src/game/logic/validation.js': {
+          '../../src/game/logic/validation.js': {
             validateDealerDiscard: validateDealerDiscardMock,
             validateBid: sinon.stub()
           },
-          '/app/src/utils/logger.js': baseLoggerMock,
-          '/app/src/game/logic/errors.js': { PhaseLogicError, CardNotInHandError, InvalidDiscardError, NotPlayersTurnError, ValidationError, InvalidPhaseError }
+          '../../src/utils/logger.js': baseLoggerMock,
+          '../../src/game/logic/errors.js': { PhaseLogicError, CardNotInHandError, InvalidDiscardError, NotPlayersTurnError, ValidationError, InvalidPhaseError }
       });
       handleDealerDiscard = biddingPhaseModule.handleDealerDiscard;
 
@@ -266,14 +266,14 @@ describe('BiddingPhase Logic', () => {
     beforeEach(async () => {
       validateBidMock = sinon.stub();
       const biddingPhaseModule = await esmock('../../src/game/phases/biddingPhase.js', {
-          '/app/src/game/logic/validation.js': {
+          '../../src/game/logic/validation.js': {
             validateBid: validateBidMock,
             // Provide stubs for other validation functions if they are in the same file
             // and might be called by other functions in biddingPhase.js
             validateDealerDiscard: sinon.stub(),
           },
-          '/app/src/utils/logger.js': baseLoggerMock,
-          '/app/src/game/logic/errors.js': { PhaseLogicError, InvalidBidError, NotPlayersTurnError, ValidationError, InvalidPhaseError }
+          '../../src/utils/logger.js': baseLoggerMock,
+          '../../src/game/logic/errors.js': { PhaseLogicError, InvalidBidError, NotPlayersTurnError, ValidationError, InvalidPhaseError }
       });
       handleCallTrumpDecision = biddingPhaseModule.handleCallTrumpDecision;
 

--- a/test/phases/goAlonePhase.unit.test.js
+++ b/test/phases/goAlonePhase.unit.test.js
@@ -53,9 +53,9 @@ describe('GoAlonePhase Logic', () => {
     getPartnerMock = sinon.stub();
 
     const goAlonePhaseModule = await esmock('../../src/game/phases/goAlonePhase.js', {
-      '/app/src/game/state.js': { updateGameState: updateGameStateStub },
-      '/app/src/utils/logger.js': defaultLoggerMock,
-      '/app/src/utils/players.js': {
+      '../../src/game/state.js': { updateGameState: updateGameStateStub },
+      '../../src/utils/logger.js': defaultLoggerMock,
+      '../../src/utils/players.js': {
         getNextPlayer: getNextPlayerMock,
         getPartner: getPartnerMock,
       },

--- a/test/phases/lobbyPhase.unit.test.js
+++ b/test/phases/lobbyPhase.unit.test.js
@@ -50,8 +50,8 @@ describe('LobbyPhase Logic', () => {
     });
 
     const lobbyPhaseModule = await esmock('../../src/game/phases/lobbyPhase.js', {
-      '/app/src/game/state.js': { updateGameState: updateGameStateStub },
-      '/app/src/utils/logger.js': defaultLoggerMock,
+      '../../src/game/state.js': { updateGameState: updateGameStateStub },
+      '../../src/utils/logger.js': defaultLoggerMock,
       // Errors are imported by test file for assertions
     });
     attemptToStartGame = lobbyPhaseModule.attemptToStartGame;

--- a/test/phases/playingPhase.unit.test.js
+++ b/test/phases/playingPhase.unit.test.js
@@ -77,11 +77,11 @@ describe('PlayingPhase Logic', () => {
       getNextPlayerMock = sinon.stub().returns(PLAYER_ROLES[2]); // Default next player (North)
 
       const playingPhaseModule = await esmock('../../src/game/phases/playingPhase.js', {
-        '/app/src/game/logic/validation.js': { validatePlay: validatePlayMock },
-        '/app/src/utils/deck.js': { getCardRank: getCardRankMock },
-        '/app/src/utils/players.js': { getNextPlayer: getNextPlayerMock },
-        '/app/src/utils/logger.js': loggerMock, // Assuming playingPhase.js might use logger directly
-        '/app/src/game/state.js': { // Mock updateGameState to simplify state checks
+        '../../src/game/logic/validation.js': { validatePlay: validatePlayMock },
+        '../../src/utils/deck.js': { getCardRank: getCardRankMock },
+        '../../src/utils/players.js': { getNextPlayer: getNextPlayerMock },
+        '../../src/utils/logger.js': loggerMock, // Assuming playingPhase.js might use logger directly
+        '../../src/game/state.js': { // Mock updateGameState to simplify state checks
             updateGameState: (fn) => {
                 const current = JSON.parse(JSON.stringify(baseGameState)); // Simulate access to current state
                 const changes = fn(current);
@@ -257,9 +257,9 @@ describe('PlayingPhase Logic', () => {
     beforeEach(async () => {
       getCardRankMock = sinon.stub();
       const playingPhaseModule = await esmock('../../src/game/phases/playingPhase.js', {
-        '/app/src/utils/deck.js': { getCardRank: getCardRankMock },
+        '../../src/utils/deck.js': { getCardRank: getCardRankMock },
         // Mock other dependencies if determineTrickWinner starts using them
-        '/app/src/utils/logger.js': loggerMock,
+        '../../src/utils/logger.js': loggerMock,
       });
       determineTrickWinner = playingPhaseModule.determineTrickWinner;
     });

--- a/test/phases/scoringPhase.unit.test.js
+++ b/test/phases/scoringPhase.unit.test.js
@@ -59,12 +59,11 @@ describe('ScoringPhase Logic', () => {
 
     beforeEach(async () => {
       updateGameMock = sinon.stub().resolves();
-      const absModulePath = '/app/src/game/phases/scoringPhase.js';
-      const scoringPhaseModule = await esmock(absModulePath, {
-        '/app/src/db/gameRepository.js': {
+      const scoringPhaseModule = await esmock('../../src/game/phases/scoringPhase.js', {
+        '../../src/db/gameRepository.js': {
           gameRepository: { updateGame: updateGameMock }
         },
-        '/app/src/utils/logger.js': defaultLoggerMock,
+        '../../src/utils/logger.js': defaultLoggerMock,
       });
       calculateAndApplyScore = scoringPhaseModule.calculateAndApplyScore;
     });
@@ -174,8 +173,8 @@ describe('ScoringPhase Logic', () => {
     beforeEach(async () => {
       resetFullGameMock = sinon.stub().returns({ gameId: 'newTestGame', gamePhase: GAME_PHASES.LOBBY });
       const scoringPhaseModule = await esmock('../../src/game/phases/scoringPhase.js', {
-        '/app/src/game/state.js': { resetFullGame: resetFullGameMock },
-        '/app/src/utils/logger.js': defaultLoggerMock,
+        '../../src/game/state.js': { resetFullGame: resetFullGameMock },
+        '../../src/utils/logger.js': defaultLoggerMock,
         // Mock other external deps if handleNewGameRequest uses them
       });
       handleNewGameRequest = scoringPhaseModule.handleNewGameRequest;

--- a/test/phases/startNewHandPhase.unit.test.js
+++ b/test/phases/startNewHandPhase.unit.test.js
@@ -62,13 +62,13 @@ describe('StartNewHandPhase Logic', () => {
     getNextPlayerMock = sinon.stub();
 
     const startNewHandPhaseModule = await esmock('../../src/game/phases/startNewHandPhase.js', {
-      '/app/src/utils/deck.js': {
+      '../../src/utils/deck.js': {
         createDeck: createDeckMock,
         shuffleDeck: shuffleDeckMock,
         cardToId: cardToIdMock,
       },
-      '/app/src/utils/players.js': { getNextPlayer: getNextPlayerMock },
-      '/app/src/utils/logger.js': defaultLoggerMock,
+      '../../src/utils/players.js': { getNextPlayer: getNextPlayerMock },
+      '../../src/utils/logger.js': defaultLoggerMock,
       // No state.js or gameRepository.js mocks needed as startNewHand is pure
     });
     startNewHand = startNewHandPhaseModule.startNewHand;


### PR DESCRIPTION
Updated esmock paths in test files under `test/phases` to use relative paths instead of absolute paths. This improves portability and consistency.