### PR TITLE
Fix: Update error assertions in validation.unit.test.js

### DIFF
--- a/test/game/logic/validation.unit.test.js
+++ b/test/game/logic/validation.unit.test.js
@@ -63,37 +63,37 @@ describe('Validation Logic - validatePlay', () => {
 
   // Test cases for basic argument validation (uses generalValidatePlay)
   it('should throw ValidationError if gameState is missing', () => {
-    expect(() => generalValidatePlay(null, player1Hand, player1Hand[0], player1Role)).to.throw(ValidationError);
+    expect(() => generalValidatePlay(null, player1Hand, player1Hand[0], player1Role)).to.throw(ValidationError, 'Internal error: Missing data for play validation.');
   });
   it('should throw ValidationError if playerHand is missing', () => {
-    expect(() => generalValidatePlay(baseGameState, null, player1Hand[0], player1Role)).to.throw(ValidationError);
+    expect(() => generalValidatePlay(baseGameState, null, player1Hand[0], player1Role)).to.throw(ValidationError, 'Internal error: Missing data for play validation.');
   });
   it('should throw ValidationError if cardToPlay is missing', () => {
-    expect(() => generalValidatePlay(baseGameState, player1Hand, null, player1Role)).to.throw(ValidationError);
+    expect(() => generalValidatePlay(baseGameState, player1Hand, null, player1Role)).to.throw(ValidationError, 'Internal error: Missing data for play validation.');
   });
     it('should throw ValidationError if cardToPlay.id is missing', () => {
-    expect(() => generalValidatePlay(baseGameState, player1Hand, { suit: SUITS.CLUBS, value: VALUES.ACE }, player1Role)).to.throw(ValidationError);
+    expect(() => generalValidatePlay(baseGameState, player1Hand, { suit: SUITS.CLUBS, value: VALUES.ACE }, player1Role)).to.throw(ValidationError, 'Internal error: Missing data for play validation.');
   });
   it('should throw ValidationError if playerRole is missing', () => {
-    expect(() => generalValidatePlay(baseGameState, player1Hand, player1Hand[0], null)).to.throw(ValidationError);
+    expect(() => generalValidatePlay(baseGameState, player1Hand, player1Hand[0], null)).to.throw(ValidationError, 'Internal error: Missing data for play validation.');
   });
 
   // Test case for invalid game phase (uses generalValidatePlay)
   it('should throw InvalidPhaseError if game is not in PLAYING phase', () => {
     const gameState = { ...baseGameState, gamePhase: GAME_PHASES.DEALER_DISCARD };
-    expect(() => generalValidatePlay(gameState, player1Hand, player1Hand[0], player1Role)).to.throw(InvalidPhaseError, /Cannot play card during .*/);
+    expect(() => generalValidatePlay(gameState, player1Hand, player1Hand[0], player1Role)).to.throw(InvalidPhaseError, `Cannot play card during ${GAME_PHASES.DEALER_DISCARD} phase.`);
   });
 
   // Test case for not player's turn (uses generalValidatePlay)
   it('should throw NotPlayersTurnError if it is not the player\'s turn', () => {
     const gameState = { ...baseGameState, currentPlayer: PLAYER_ROLES[1] }; // PLAYER_2's turn
-    expect(() => generalValidatePlay(gameState, player1Hand, player1Hand[0], player1Role)).to.throw(NotPlayersTurnError);
+    expect(() => generalValidatePlay(gameState, player1Hand, player1Hand[0], player1Role)).to.throw(NotPlayersTurnError, `Not ${PLAYER_ROLES[0]}'s turn. It is ${PLAYER_ROLES[1]}'s turn.`);
   });
 
   // Test case for card not in hand (uses generalValidatePlay)
   it('should throw CardNotInHandError if the card is not in player\'s hand', () => {
     const cardNotInHand = { id: 'QH', suit: SUITS.HEARTS, value: VALUES.QUEEN };
-    expect(() => generalValidatePlay(baseGameState, player1Hand, cardNotInHand, player1Role)).to.throw(CardNotInHandError);
+    expect(() => generalValidatePlay(baseGameState, player1Hand, cardNotInHand, player1Role)).to.throw(CardNotInHandError, `Card QH is not in ${PLAYER_ROLES[0]}'s hand.`);
   });
 
   // Test cases for following suit - This block will manage its own validatePlay and isLeftBowerMock
@@ -184,7 +184,7 @@ describe('Validation Logic - validatePlay', () => {
       // isLeftBowerMock(TC, Spades) -> false. TC is CLUBS.
       // Player has TC (true Club), card played JC (Spade). Should throw.
       expect(() => validatePlay(gameState, localPlayerHand, cardToPlay, player1Role))
-        .to.throw(MustFollowSuitError);
+        .to.throw(MustFollowSuitError, `Must follow suit. Led suit is ${SUITS.CLUBS}, attempted to play ${SUITS.SPADES}.`);
 
       // Playing the TC (true Club) should be valid
       const cardToPlayCorrectly = localPlayerHand[1]; // TC
@@ -207,7 +207,7 @@ describe('Validation Logic - validatePlay', () => {
       // isLeftBowerMock(AC, Spades) -> false. AC is CLUBS.
       // Player has Spades (AS, KS). Led suit SPADES. Card played CLUBS. Should throw.
       expect(() => validatePlay(gameState, player1Hand, cardToPlayWrong, player1Role))
-        .to.throw(MustFollowSuitError);
+        .to.throw(MustFollowSuitError, `Must follow suit. Led suit is ${SUITS.SPADES}, attempted to play ${SUITS.CLUBS}.`);
     });
 
     it('should allow playing Left Bower if it matches the led suit (which is trump)', () => {
@@ -242,7 +242,7 @@ describe('Validation Logic - validatePlay', () => {
 
         // Player has KH (Heart), must play it.
         expect(() => validatePlay(currentGameState, hand, cardToAttempt, player1Role))
-            .to.throw(MustFollowSuitError);
+            .to.throw(MustFollowSuitError, `Must follow suit. Led suit is ${SUITS.HEARTS}, attempted to play ${SUITS.SPADES}.`);
     });
 
 
@@ -304,28 +304,28 @@ describe('Validation Logic - validateBid', () => {
 
   // Argument validation
   it('should throw ValidationError if gameState is missing', () => {
-    expect(() => validateBid(null, PLAYER_ROLES[0], 'pass')).to.throw(ValidationError);
+    expect(() => validateBid(null, PLAYER_ROLES[0], 'pass')).to.throw(ValidationError, 'Internal error: Missing or invalid data for bid validation.');
   });
   it('should throw ValidationError if playerRole is missing', () => {
-    expect(() => validateBid(baseBidGameState, null, 'pass')).to.throw(ValidationError);
+    expect(() => validateBid(baseBidGameState, null, 'pass')).to.throw(ValidationError, 'Internal error: Missing or invalid data for bid validation.');
   });
   it('should throw ValidationError if decision is missing', () => {
-    expect(() => validateBid(baseBidGameState, PLAYER_ROLES[0], null)).to.throw(ValidationError);
+    expect(() => validateBid(baseBidGameState, PLAYER_ROLES[0], null)).to.throw(ValidationError, 'Internal error: Missing or invalid data for bid validation.');
   });
   it('should throw ValidationError if playerRole is invalid', () => {
-    expect(() => validateBid(baseBidGameState, 'invalidRole', 'pass')).to.throw(ValidationError);
+    expect(() => validateBid(baseBidGameState, 'invalidRole', 'pass')).to.throw(ValidationError, 'Internal error: Missing or invalid data for bid validation.');
   });
 
   // Turn validation
   it('should throw NotPlayersTurnError if it is not the current player\'s turn', () => {
     const gameState = { ...baseBidGameState, currentPlayer: PLAYER_ROLES[1] };
-    expect(() => validateBid(gameState, PLAYER_ROLES[0], 'pass')).to.throw(NotPlayersTurnError);
+    expect(() => validateBid(gameState, PLAYER_ROLES[0], 'pass')).to.throw(NotPlayersTurnError, `Not ${PLAYER_ROLES[0]}'s turn. It is ${PLAYER_ROLES[1]}'s turn.`);
   });
 
   // Phase validation
   it('should throw InvalidPhaseError if bidding is attempted outside bidding phases', () => {
     const gameState = { ...baseBidGameState, gamePhase: GAME_PHASES.PLAYING };
-    expect(() => validateBid(gameState, PLAYER_ROLES[0], 'pass')).to.throw(InvalidPhaseError, /Cannot make bid decision during .*/);
+    expect(() => validateBid(gameState, PLAYER_ROLES[0], 'pass')).to.throw(InvalidPhaseError, `Cannot make bid decision during ${GAME_PHASES.PLAYING} phase.`);
   });
 
   // Round 1 Bidding Logic
@@ -343,10 +343,10 @@ describe('Validation Logic - validateBid', () => {
       expect(validateBid(baseBidGameState, PLAYER_ROLES[0], 'pass')).to.equal(true);
     });
     it('should throw InvalidBidError for "callTrump" decision', () => {
-      expect(() => validateBid(baseBidGameState, PLAYER_ROLES[0], 'callTrump', SUITS.CLUBS)).to.throw(InvalidBidError);
+      expect(() => validateBid(baseBidGameState, PLAYER_ROLES[0], 'callTrump', SUITS.CLUBS)).to.throw(InvalidBidError, `Invalid decision 'callTrump' for ${GAME_PHASES.ORDER_UP_ROUND1}.`);
     });
     it('should throw InvalidBidError for other invalid decisions', () => {
-      expect(() => validateBid(baseBidGameState, PLAYER_ROLES[0], 'invalidDecision')).to.throw(InvalidBidError);
+      expect(() => validateBid(baseBidGameState, PLAYER_ROLES[0], 'invalidDecision')).to.throw(InvalidBidError, `Invalid decision 'invalidDecision' for ${GAME_PHASES.ORDER_UP_ROUND1}.`);
     });
     it('should allow dealer to "orderUp" (accept turn card)', () => {
       const gameState = { ...baseBidGameState, currentPlayer: PLAYER_ROLES[3] }; // Dealer's turn
@@ -380,16 +380,16 @@ describe('Validation Logic - validateBid', () => {
       expect(validateBid(baseBidGameState, PLAYER_ROLES[0], 'pass')).to.equal(true);
     });
     it('should throw InvalidBidError for "orderUp" decision', () => {
-      expect(() => validateBid(baseBidGameState, PLAYER_ROLES[0], 'orderUp')).to.throw(InvalidBidError);
+      expect(() => validateBid(baseBidGameState, PLAYER_ROLES[0], 'orderUp')).to.throw(InvalidBidError, `Invalid decision 'orderUp' for ${GAME_PHASES.ORDER_UP_ROUND2}.`);
     });
     it('should throw InvalidBidError for "callTrump" with an invalid suit string', () => {
-      expect(() => validateBid(baseBidGameState, PLAYER_ROLES[0], 'callTrump', 'invalidSuit')).to.throw(InvalidBidError);
+      expect(() => validateBid(baseBidGameState, PLAYER_ROLES[0], 'callTrump', 'invalidSuit')).to.throw(InvalidBidError, 'Invalid suit provided for callTrump decision.');
     });
     it('should throw InvalidBidError for "callTrump" with no suit', () => {
-      expect(() => validateBid(baseBidGameState, PLAYER_ROLES[0], 'callTrump', null)).to.throw(InvalidBidError);
+      expect(() => validateBid(baseBidGameState, PLAYER_ROLES[0], 'callTrump', null)).to.throw(InvalidBidError, 'Invalid suit provided for callTrump decision.');
     });
     it('should throw InvalidBidError for "callTrump" with the turned down suit', () => {
-      expect(() => validateBid(baseBidGameState, PLAYER_ROLES[0], 'callTrump', SUITS.SPADES)).to.throw(InvalidBidError);
+      expect(() => validateBid(baseBidGameState, PLAYER_ROLES[0], 'callTrump', SUITS.SPADES)).to.throw(InvalidBidError, `Cannot call the suit that was turned down (${SUITS.SPADES}).`);
     });
 
     describe('Stick the Dealer rule', () => {
@@ -404,13 +404,13 @@ describe('Validation Logic - validateBid', () => {
       });
 
       it('should throw InvalidBidError if dealer tries to "pass" (stick the dealer)', () => {
-        expect(() => validateBid(baseBidGameState, PLAYER_ROLES[3], 'pass')).to.throw(InvalidBidError);
+        expect(() => validateBid(baseBidGameState, PLAYER_ROLES[3], 'pass')).to.throw(InvalidBidError, 'Dealer must call a suit in this situation (stick the dealer).');
       });
       it('should allow dealer to "callTrump" with a valid suit (stick the dealer)', () => {
         expect(() => validateBid(baseBidGameState, PLAYER_ROLES[3], 'callTrump', SUITS.CLUBS)).to.not.throw();
       });
        it('should throw InvalidBidError if dealer tries to "callTrump" with turned down suit (stick the dealer)', () => {
-        expect(() => validateBid(baseBidGameState, PLAYER_ROLES[3], 'callTrump', SUITS.SPADES)).to.throw(InvalidBidError);
+        expect(() => validateBid(baseBidGameState, PLAYER_ROLES[3], 'callTrump', SUITS.SPADES)).to.throw(InvalidBidError, `Cannot call the suit that was turned down (${SUITS.SPADES}).`);
       });
     });
   });
@@ -451,26 +451,26 @@ describe('Validation Logic - validateDealerDiscard', () => {
 
   // Argument validation
   it('should throw ValidationError if gameState is missing', () => {
-    expect(() => validateDealerDiscard(null, dealerRole, cardToDiscard, dealerHand)).to.throw(ValidationError);
+    expect(() => validateDealerDiscard(null, dealerRole, cardToDiscard, dealerHand)).to.throw(ValidationError, 'Internal error: Missing data for discard validation.');
   });
   it('should throw ValidationError if playerRole is missing', () => {
-    expect(() => validateDealerDiscard(baseDiscardGameState, null, cardToDiscard, dealerHand)).to.throw(ValidationError);
+    expect(() => validateDealerDiscard(baseDiscardGameState, null, cardToDiscard, dealerHand)).to.throw(ValidationError, 'Internal error: Missing data for discard validation.');
   });
   it('should throw ValidationError if cardToDiscard is missing', () => {
-    expect(() => validateDealerDiscard(baseDiscardGameState, dealerRole, null, dealerHand)).to.throw(ValidationError);
+    expect(() => validateDealerDiscard(baseDiscardGameState, dealerRole, null, dealerHand)).to.throw(ValidationError, 'Internal error: Missing data for discard validation.');
   });
   it('should throw ValidationError if cardToDiscard.id is missing', () => {
     const invalidCard = { suit: SUITS.CLUBS, value: VALUES.TEN }; // Missing id
-    expect(() => validateDealerDiscard(baseDiscardGameState, dealerRole, invalidCard, dealerHand)).to.throw(ValidationError);
+    expect(() => validateDealerDiscard(baseDiscardGameState, dealerRole, invalidCard, dealerHand)).to.throw(ValidationError, 'Internal error: Missing data for discard validation.');
   });
   it('should throw ValidationError if playerHand is missing', () => {
-    expect(() => validateDealerDiscard(baseDiscardGameState, dealerRole, cardToDiscard, null)).to.throw(ValidationError);
+    expect(() => validateDealerDiscard(baseDiscardGameState, dealerRole, cardToDiscard, null)).to.throw(ValidationError, 'Internal error: Missing data for discard validation.');
   });
 
   // Phase validation
   it('should throw InvalidPhaseError if not in DEALER_DISCARD phase', () => {
     const gameState = { ...baseDiscardGameState, gamePhase: GAME_PHASES.PLAYING };
-    expect(() => validateDealerDiscard(gameState, dealerRole, cardToDiscard, dealerHand)).to.throw(InvalidPhaseError, /Cannot discard card during .*/);
+    expect(() => validateDealerDiscard(gameState, dealerRole, cardToDiscard, dealerHand)).to.throw(InvalidPhaseError, `Cannot discard card during ${GAME_PHASES.PLAYING} phase.`);
   });
 
   // Dealer validation
@@ -479,19 +479,19 @@ describe('Validation Logic - validateDealerDiscard', () => {
     const gameState = { ...baseDiscardGameState, dealer: dealerRole, currentPlayer: nonDealerRole }; // Still dealerRole in gameState.dealer, but nonDealerRole is attempting
     // To make this test meaningful, current player should also be the nonDealerRole if game logic enforces that only current player can act
     // However, this specific check is about *being* the dealer vs. *not being* the dealer.
-    expect(() => validateDealerDiscard(gameState, nonDealerRole, cardToDiscard, dealerHand)).to.throw(InvalidDiscardError);
+    expect(() => validateDealerDiscard(gameState, nonDealerRole, cardToDiscard, dealerHand)).to.throw(InvalidDiscardError, `Only the dealer (${dealerRole}) can discard. Player ${nonDealerRole} attempted.`);
   });
 
   // Turn validation
   it('should throw NotPlayersTurnError if it is not the current player\'s turn (even if player is dealer)', () => {
     const gameState = { ...baseDiscardGameState, currentPlayer: PLAYER_ROLES[1] }; // Dealer is player1, but current player is player2
-    expect(() => validateDealerDiscard(gameState, dealerRole, cardToDiscard, dealerHand)).to.throw(NotPlayersTurnError);
+    expect(() => validateDealerDiscard(gameState, dealerRole, cardToDiscard, dealerHand)).to.throw(NotPlayersTurnError, `Not ${dealerRole}'s turn. It is ${PLAYER_ROLES[1]}'s turn.`);
   });
 
   // Card in hand validation
   it('should throw CardNotInHandError if cardToDiscard is not in dealerHand', () => {
     const cardNotInHand = { id: 'QH', suit: SUITS.HEARTS, value: VALUES.QUEEN };
-    expect(() => validateDealerDiscard(baseDiscardGameState, dealerRole, cardNotInHand, dealerHand)).to.throw(CardNotInHandError);
+    expect(() => validateDealerDiscard(baseDiscardGameState, dealerRole, cardNotInHand, dealerHand)).to.throw(CardNotInHandError, `Card QH is not in dealer's hand to discard.`);
   });
 
   // Valid discard


### PR DESCRIPTION
Updated Chai assertions in validation.unit.test.js to include specific error messages, ensuring tests correctly match thrown errors as per application logic. This resolves issues where tests expected generic errors but received errors with messages.