### PR TITLE
I've fixed the failing validation tests.

### DIFF
--- a/src/game/logic/validation.js
+++ b/src/game/logic/validation.js
@@ -218,9 +218,7 @@ function validateDealerDiscard(
   }
 
   if (gameState.dealer !== playerRole) {
-    throw new InvalidDiscardError(
-      `Only the dealer (${gameState.dealer}) can discard. Player ${playerRole} attempted.`,
-    );
+    throw new NotPlayersTurnError(playerRole, gameState.dealer);
   }
 
   if (gameState.currentPlayer !== playerRole) {


### PR DESCRIPTION
The `validateDealerDiscard` function was throwing an `InvalidDiscardError` when a non-dealer tried to discard, but the test was expecting a `NotPlayersTurnError`. This change fixes the issue by throwing the correct error type.